### PR TITLE
[ENH] Add duecredit, move tedana functions to utils, and some light refactoring.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Other
+TED/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,7 +20,7 @@ Containerized versions
 To access a containerized version of ``meica`` simply pull the latest Docker image.
 This can be accomplished with the following command:
 
-``docker pull emdupre/meica``
+``docker pull emdupre/meica:0.0.1``
 
 Local installation
 ------------------

--- a/meica/__init__.py
+++ b/meica/__init__.py
@@ -1,2 +1,29 @@
-from meica.meica import *
-import meica.tedana
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+"""
+MEICA: A Python package for multi-echo independent/principal component analysis.
+"""
+
+from .version import __version__
+from .due import due, Doi, BibTeX
+
+from .meica import afni_fname_parse
+from .alignp_mepi_anat import dsprefix
+from .t2smap import t2sadmap
+from .tedana import do_svm
+from .utils import cat2echos
+
+
+__all__ = ['meica', 'tedana', 't2smap', 'alignp_mepi_anat', 'utils']
+
+# Citation for the algorithm.
+due.cite(Doi('10.1016/j.neuroimage.2011.12.028'),
+         description='Introduces MEICA.',
+         version=__version__, path='meica', cite_module=True)
+due.cite(Doi('10.1073/pnas.1301725110'),
+         description='Improves MEICA.',
+         version=__version__, path='meica', cite_module=True)
+
+# Cleanup
+del due, Doi, BibTeX
+del afni_fname_parse, dsprefix, t2sadmap, do_svm, cat2echos

--- a/meica/alignp_mepi_anat.py
+++ b/meica/alignp_mepi_anat.py
@@ -5,8 +5,7 @@ import sys
 import os.path
 import subprocess
 from re import split as resplit
-from os import system,getcwd,mkdir,chdir,popen
-from optparse import OptionParser,OptionGroup
+from os import system, getcwd, mkdir, chdir, popen
 
 
 def dsprefix(idn):
@@ -124,43 +123,3 @@ def runproc(script_prefix, scrlines):
     ofh.write("\n".join(scrlines))
     ofh.close()
     os.system("bash %s" % script_name)
-
-
-if __name__=='__main__':
-
-    parser=OptionParser()
-    parser.add_option('-t',"",dest='t2s',help="T2* volume",default='')
-    parser.add_option('-s',"",dest='s0',help="Skull-stripped S0 weighted volume, optional, for masking T2*",default='')
-    parser.add_option('-a',"",dest='anat',help="Anatomical volume",default='')
-    parser.add_option('-p',"",dest='prefix',help="Alignment matrix prefix" ,default='')
-    parser.add_option('',"--cmass",action='store_true',dest='cmass',help="Align cmass before main co-registration" ,default=False)
-    parser.add_option('',"--autocmass",action='store_false',dest='autocmass',help="Automatic cmass detection (default yes)" ,default=True)
-    parser.add_option('',"--maxrot",dest='maxrot',help="Maximum rotation, default 30" ,default='30')
-    parser.add_option('',"--maxshift",dest='maxshf',help="Maximum shift, default 30" ,default='30')
-    parser.add_option('',"--maxscl",dest='maxscl',help="Maximum scale, default 1.01" ,default='1.01')
-    (options,args) = parser.parse_args()
-
-    """
-    Set up and cd into directory
-    """
-    sl = []
-    startdir = os.path.abspath(os.path.curdir)
-    walignp_dirname = "alignp.%s" % (options.prefix)
-    sl.append("rm -rf %s " % walignp_dirname)
-    sl.append("mkdir %s " % walignp_dirname)
-    sl.append("cd %s " % walignp_dirname)
-
-    """Import datasets"""
-    t2s_name,s0_name,anat_name = import_datasets([options.t2s,options.s0,options.anat])
-
-    """Filter and segment T2* volume to produce T2* base and weight volumes"""
-    basevol,weightvol = graywt(t2s_name,s0_name)
-
-    """Run 3dAllineate"""
-    allin_volume,allin_matrix = allineate(anat_name,weightvol,basevol,options.prefix,options.maxrot,options.maxshf,options.maxscl,options.cmass)
-
-    """For auto center-of-mass, check dice of COM and no-COM options"""
-    cmselect(basevol,allin_volume)
-
-    """Run procedure"""
-    runproc(options.prefix, sl)

--- a/meica/due.py
+++ b/meica/due.py
@@ -1,0 +1,67 @@
+# emacs: at the end of the file
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
+"""
+Stub file for a guaranteed safe import of duecredit constructs:  if duecredit
+is not available.
+To use it, place it into your project codebase to be imported, e.g. copy as
+    cp stub.py /path/tomodule/module/due.py
+Note that it might be better to avoid naming it duecredit.py to avoid shadowing
+installed duecredit.
+Then use in your code as
+    from .due import due, Doi, BibTeX
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+Origin:     Originally a part of the duecredit
+Copyright:  2015-2016  DueCredit developers
+License:    BSD-2
+"""
+
+from builtins import str
+from builtins import object
+__version__ = '0.0.5'
+
+
+class InactiveDueCreditCollector(object):
+    """Just a stub at the Collector which would not do anything"""
+    def _donothing(self, *args, **kwargs):
+        """Perform no good and no bad"""
+        pass
+
+    def dcite(self, *args, **kwargs):
+        """If I could cite I would"""
+        def nondecorating_decorator(func):
+            return func
+        return nondecorating_decorator
+
+    cite = load = add = _donothing
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
+
+
+def _donothing_func(*args, **kwargs):
+    """Perform no good and no bad"""
+    pass
+
+
+try:
+    from duecredit import due, BibTeX, Doi, Url
+    if 'due' in locals() and not hasattr(due, 'cite'):
+        raise RuntimeError(
+            "Imported due lacks .cite. DueCredit is now disabled")
+except Exception as e:
+    if type(e).__name__ != 'ImportError':
+        import logging
+        logging.getLogger("duecredit").error(
+            "Failed to import duecredit due to %s" % str(e))
+    # Initiate due stub
+    due = InactiveDueCreditCollector()
+    BibTeX = Doi = Url = _donothing_func
+
+# Emacs mode definitions
+# Local Variables:
+# mode: python
+# py-indent-offset: 4
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:

--- a/meica/meica.py
+++ b/meica/meica.py
@@ -1,10 +1,11 @@
-#!/usr/bin/env python
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
 
 import re
 import os
 import sys
-import glob
 import argparse
+from glob import glob
 
 import numpy as np
 import nibabel as nib
@@ -254,11 +255,11 @@ def format_dset(inset):
         if '[' in inset:  # parse shorthand file spec
         # love this option as an end user, hate it as a dev
             fparts = re.split(r'[\[\],]',inset)
-            datasets_in = glob.glob(fparts[0] + '*')
+            datasets_in = glob(fparts[0] + '*')
 
             for i, d in enumerate(datasets_in):
                 if '.HEAD' in d:
-                    datasets_in = glob.glob(fparts[0] + '*.BRIK.gz')
+                    datasets_in = glob(fparts[0] + '*.BRIK.gz')
 
             prefix, trailing, ftype = fname_parse(datasets_in)
 
@@ -344,9 +345,9 @@ def format_inset(inset, tes, e=2):
     setname   = prefix + ''.join(echo_nums) + trailing
 
     if '+' in ftype:
-        datasets = glob.glob(prefix + '*' + '.BRIK.gz')
+        datasets = glob(prefix + '*' + '.BRIK.gz')
     else:
-        datasets = glob.glob(prefix + '*')
+        datasets = glob(prefix + '*')
 
     try:
         assert len(echo_nums) == len(datasets)
@@ -485,229 +486,6 @@ def find_CM(fname):
     return cx, cy, cz
 
 
-def get_parser():
-    """
-    Parses command line inputs
-
-    Returns
-    -------
-    parser.parse_args() : argparse dic
-    """
-
-    # Configure options and help dialog
-    parser = argparse.ArgumentParser()
-
-    # Base processing options
-    parser.add_argument('-e',
-                        dest='tes',
-                        nargs='+',
-                        help="Echo times in ms. ex: -e 14.5 38.5 62.5",
-                        required=True)
-    parser.add_argument('-d',
-                        dest='input_ds',
-                        nargs='+',
-                        help="Input datasets. ex: -d RESTe[123].nii.gz",
-                        required=True)
-    parser.add_argument('-a',
-                        dest='anat',
-                        help="(Optional) anatomical dataset. " +
-                             "ex: -a mprage.nii.gz",
-                        default='')
-    parser.add_argument('-b',
-                        dest='basetime',
-                        help="Time to steady-state equilibration in " +
-                             "seconds(s) or volumes(v). Default 0. ex: -b 4v",
-                        default='0')
-    parser.add_argument('--MNI',
-                        dest='mni',
-                        action='store_true',
-                        help="Warp to MNI standard space.",
-                        default=False)
-    parser.add_argument('--strict',
-                        dest='strict',
-                        action='store_true',
-                        help="Use strict component selection, suitable with" +
-                             " large-voxel, high-SNR data",
-                        default=False)
-
-    # Extended options for processing
-    extopts = parser.add_argument_group("Additional processing options")
-    extopts.add_argument("--qwarp",
-                         dest='qwarp',
-                         action='store_true',
-                         help="Nonlinear warp to standard space using QWarp," +
-                              " requires --MNI or --space).",
-                         default=False)
-    extopts.add_argument("--native",
-                         dest='native',
-                         action='store_true',
-                         help="Output native space results in addition to " +
-                              "standard space results.",
-                         default=False)
-    extopts.add_argument("--space",
-                         dest='space',
-                         help="Path to specific standard space template for " +
-                              "affine anatomical normalization.",
-                         default=False)
-    extopts.add_argument("--fres",
-                         dest='fres',
-                         help="Specify functional voxel dimensions in mm " +
-                              "(iso.) for resampling during preprocessing." +
-                              "ex: --fres=2.5",
-                         default=False)
-    extopts.add_argument("--no_skullstrip",
-                         action="store_true",
-                         dest='no_skullstrip',
-                         help="Anat is intensity-normalized and " +
-                              "skull-stripped (for use with '-a' flag).",
-                         default=False)
-    extopts.add_argument("--no_despike",
-                         action="store_true",
-                         dest='no_despike',
-                         help="Do not de-spike functional data. " +
-                              "Default is to de-spike, recommended.",
-                         default=False)
-    extopts.add_argument("--no_axialize",
-                         action="store_true",
-                         dest='no_axialize',
-                         help="Do not re-write dataset in axial-first order." +
-                              " Default is to axialize, recommended.",
-                         default=False)
-    extopts.add_argument("--mask_mode",
-                         dest='mask_mode',
-                         help="Mask functional with help from anatomical or" +
-                              " standard space images." +
-                              " Options: 'anat' or 'template'.",
-                         default='func')
-    extopts.add_argument("--coreg_mode",
-                         dest='coreg_mode',
-                         help="Coregistration with Local Pearson and T2* weights "+
-                              "(default), or use align_epi_anat.py (edge method)."+
-                              "Options: 'lp-t2s' or 'aea'",
-                         default='lp-t2s')
-    extopts.add_argument("--smooth",
-                         dest='FWHM',
-                         help="FWHM smoothing with 3dBlurInMask. Default none. " +
-                              "ex: --smooth 3mm ",
-                         default='0mm')
-    extopts.add_argument("--align_base",
-                         dest='align_base',
-                         help="Explicitly specify base dataset for volume " +
-                              "registration",
-                         default='')
-    extopts.add_argument("--TR",
-                         dest='TR',
-                         help="TR. Read by default from dataset header",
-                         default='')
-    extopts.add_argument("--tpattern",
-                         dest='tpattern',
-                         help="Slice timing (i.e. alt+z, see 3dTshift -help)." +
-                              " Default from header.",
-                         default='')
-    extopts.add_argument("--align_args",
-                         dest='align_args',
-                         help="Additional arguments to anatomical-functional" +
-                              " co-registration routine",
-                         default='')
-    extopts.add_argument("--ted_args",
-                         dest='ted_args',
-                         help="Additional arguments to " +
-                              "TE-dependence analysis",
-                         default='')
-
-    # Additional, extended preprocessing options
-    #  no help provided, caveat emptor
-    extopts.add_argument("--select_only",
-                         dest='select_only',
-                         action='store_true',
-                         help=argparse.SUPPRESS,
-                         default=False)
-    extopts.add_argument("--tedica_only",
-                         dest='tedica_only',
-                         action='store_true',
-                         help=argparse.SUPPRESS,
-                         default=False)
-    extopts.add_argument("--export_only",
-                         dest='export_only',
-                         action='store_true',
-                         help=argparse.SUPPRESS,
-                         default=False)
-    extopts.add_argument("--daw",
-                         dest='daw',
-                         help=argparse.SUPPRESS,
-                         default='10')
-    extopts.add_argument("--tlrc",
-                         dest='space',
-                         help=argparse.SUPPRESS,
-                         default=False)  # For backwards compat.
-    extopts.add_argument("--highpass",
-                         dest='highpass',
-                         help=argparse.SUPPRESS,
-                         default=0.0)
-    extopts.add_argument("--detrend",
-                         dest='detrend',
-                         help=argparse.SUPPRESS,
-                         default=0.)
-    extopts.add_argument("--initcost",
-                         dest='initcost',
-                         help=argparse.SUPPRESS,
-                         default='tanh')
-    extopts.add_argument("--finalcost",
-                         dest='finalcost',
-                         help=argparse.SUPPRESS,
-                         default='tanh')
-    extopts.add_argument("--sourceTEs",
-                         dest='sourceTEs',
-                         help=argparse.SUPPRESS,
-                         default='-1')
-    parser.add_argument_group(extopts)
-
-    # Extended options for running
-    runopts = parser.add_argument_group("Run options")
-    runopts.add_argument("--prefix",
-                         dest='prefix',
-                         help="Prefix for final ME-ICA output datasets.",
-                         default='')
-    runopts.add_argument("--cpus",
-                         dest='cpus',
-                         help="Maximum number of CPUs (OpenMP threads) to use. " +
-                         "Default 2.",
-                         default='2')
-    runopts.add_argument("--label",
-                         dest='label',
-                         help="Label to tag ME-ICA analysis folder.",
-                         default='')
-    runopts.add_argument("--test_proc",
-                         action="store_true",
-                         dest='test_proc',
-                         help="Align, preprocess 1 dataset then exit.",
-                         default=False)
-    runopts.add_argument("--pp_only",
-                         action="store_true",
-                         dest='preproc_only',
-                         help="Preprocess only, then exit.",
-                         default=False)
-    runopts.add_argument("--keep_int",
-                         action="store_true",
-                         dest='keep_int',
-                         help="Keep preprocessing intermediates. " +
-                              "Default delete.",
-                              default=False)
-    runopts.add_argument("--RESUME",
-                         dest='resume',
-                         action='store_true',
-                         help="Attempt to resume from normalization step " +
-                              "onwards, overwriting existing")
-    runopts.add_argument("--OVERWRITE",
-                         dest='overwrite',
-                         action="store_true",
-                         help="Overwrite existing meica directory.",
-                         default=False)
-    parser.add_argument_group(runopts)
-
-    return parser
-
-
 def gen_script(options):
     """
     Parses input options to generate working ME-ICA script based on inputs
@@ -822,7 +600,7 @@ def gen_script(options):
         raise OSError("Need at least dataset inputs and TEs. Try meica.py -h")
 
     # Check for already created meica directories
-    meicas = glob.glob('derivatives')
+    meicas = glob('derivatives')
     if any(os.path.isdir(m) for i, m in enumerate(meicas)):
         meica_exists   = True
     else: meica_exists = False
@@ -897,7 +675,7 @@ def gen_script(options):
                            "autobox anatomical, in starting directory (may " +
                            "take a little while)")
         anat_prefix, _anat_trailing, anat_ftype = fname_parse(mprage)
-        path_anat_prefix        = "{}/{}".format(startdir,anat_prefix)
+        path_anat_prefix = "{}/{}".format(startdir,anat_prefix)
 
         if oblique_mode:
             script_list.append("if [ ! -e "                             +
@@ -1594,15 +1372,16 @@ def gen_script(options):
                      'TED/feats_OC2.nii']
 
     export_vars = ['{}_tsoc', '{}_medn', '{}_T1c_medn', '{}_hikts',
-                   '{}_mefc','{}_mefl','{}_mefcz']
+                   '{}_mefc', '{}_mefl', '{}_mefcz']
 
-    export_descr = ['T2* weighted average of ME time series', 'Denoised ' +
-                    'timeseries (including thermal noise)', 'Denoised ' +
-                    'timeseries with T1 equilibration correction ' +
-                    '(including thermal noise)', 'Denoised timeseries with ' +
-                    'T1 equilibration correction (no thermal noise)',
-                    'Denoised ICA coeff. set for ME-ICR seed-based FC ' +
-                    'analysis', 'Full ICA coeff. set for component assessment',
+    export_descr = ['T2* weighted average of ME time series',
+                    'Denoised timeseries (including thermal noise)',
+                    'Denoised timeseries with T1 equilibration correction ' +
+                    '(including thermal noise)',
+                    'Denoised timeseries with T1 equilibration correction '
+                    '(no thermal noise)',
+                    'Denoised ICA coeff. set for ME-ICR seed-based FC analysis',
+                    'Full ICA coeff. set for component assessment',
                     'Z-normalized spatial component maps']
 
     for i, v in enumerate(export_vars):
@@ -1627,8 +1406,8 @@ def gen_script(options):
             if valid_qwarp_mode:
                 warp_code = 'nlw'
                 nwarpstring = "-nwarp {0}/{1}_xns2at.aff12.1D '{0}/{2}_WARP.nii.gz'".format(startdir,
-                                                                                             anat_prefix,
-                                                                                             pfix_ns_mprage + '_atnl')
+                                                                                            anat_prefix,
+                                                                                            pfix_ns_mprage + '_atnl')
                 script_list.append("3dNwarpApply " +
                                    "-overwrite {} {} ".format(nwarpstring,
                                                               export_master) +
@@ -1736,19 +1515,7 @@ def gen_script(options):
     return script_list
 
 
-def main(*args):
-    """
-    """
-    options = get_parser().parse_args(*args)
-    script_list = gen_script(options)
-
-    setname = get_setname(options.input_ds, options.tes)
-    if options.label != '': setname = setname + options.label
-
-    with open("_meica_{}.sh".format(setname), 'w') as file:
-        file.write("\n".join(script_list))
-
-
 if __name__ == '__main__':
-    raise RuntimeError("meica.py should not be run directly;\n"
-                       "Please `pip install` meica and use the `meica` command")
+    raise RuntimeError('meica.py should not be run directly;\n'
+                       'Please `pip install` meica and use the `meica` command '
+                       'or use the run_meica.py script')

--- a/meica/t2smap.py
+++ b/meica/t2smap.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
-import argparse
 import numpy as np
 import nibabel as nib
-from meica.utils import (niwrite, cat2echos,
-                         uncat2echos, makeadmask,
-                         fmask, unmask)
+
+from .utils import (niwrite, cat2echos, makeadmask, unmask)
 
 
 def t2sadmap(catd,mask,tes,masksum,start_echo):
@@ -106,40 +104,10 @@ def optcom(data,t2,tes,mask,combmode,useG=False):
     print('Out shape is ', out.shape)
     return out
 
-def get_parser():
-    """
-    Parses command line inputs for t2smap
-    Returns
-    -------
-    parser.parse_args() : argparse dic
-    """
-    parser = argparse.ArgumentParser()
-    parser.add_option('-d',
-                      nargs='+',
-                      dest='data',
-                      help="Spatially Concatenated Multi-Echo Dataset",
-                      required=True)
-    parser.add_option('-e',
-                      nargs='+',
-                      dest='tes',
-                      help="Echo times (in ms) ex: 15,39,63",
-                      required=True)
-    parser.add_option('-c',
-                      dest='combmode',
-                      help="Combination scheme for TEs: t2s (Posse 1999),ste(Poser,2006 default)",
-                      default='ste')
-    parser.add_option('-l',
-                      dest='label',
-                      help="Optional label to tag output files with",
-                      default=None)
-    return parser
 
-
-def main():
+def main(options):
     """
     """
-    options = get_parser().parse_args(*args)
-
     if options.label!=None:
         suf='_%s' % str(options.label)
     else:
@@ -188,6 +156,3 @@ def main():
     niwrite(s0,aff,'s0v%s.nii' % suf)
     niwrite(t2s,aff,'t2sv%s.nii' % suf )
     niwrite(t2sm,aff,'t2svm%s.nii' % suf )
-
-if __name__=='__main__':
-    main()

--- a/meica/t2smap.py
+++ b/meica/t2smap.py
@@ -2,7 +2,7 @@
 import numpy as np
 import nibabel as nib
 
-from .utils import (niwrite, cat2echos, makeadmask, unmask)
+from .utils import (niwrite, cat2echos, makeadmask, unmask, fmask)
 
 
 def t2sadmap(catd,mask,tes,masksum,start_echo):

--- a/meica/tedana.py
+++ b/meica/tedana.py
@@ -68,10 +68,10 @@ def do_svm(X_train, y_train, X_test, svmtype=0):
     else:
         raise ValueError('Input svmtype not in range (3)')
 
-    clf.fit(train_set, train_labs)
-    pred_labels = clf.predict(test_set)
+    clf.fit(X_train, y_train)
+    y_pred = clf.predict(X_test)
 
-    return pred_labels, clf
+    return y_pred, clf
 
 
 def spatclust(data, mask, csize, thr, header, aff, infile=None, dindex=0,

--- a/meica/tedana.py
+++ b/meica/tedana.py
@@ -291,7 +291,7 @@ def getfbounds(ne):
     """
     if not isinstance(ne, int):
         raise IOError('Input ne must be int')
-    elif ne > 0:
+    elif ne <= 0:
         raise ValueError('Input ne must be greater than 0')
 
     F05s = [None, 18.5, 10.1, 7.7, 6.6, 6.0, 5.6, 5.3, 5.1, 5.0]
@@ -424,7 +424,7 @@ def fitmodels_direct(catd, mmix, mask,
     NmD = (t2s!=0).sum()
     mu = catd.mean(axis=-1)
     tes = np.reshape(tes,(Ne,1))
-    fmin,fmid,fmax = getfbounds(ne)
+    fmin,fmid,fmax = getfbounds(Ne)
 
     #Mask arrays
     mumask   = fmask(mu,t2s!=0)

--- a/meica/tedana.py
+++ b/meica/tedana.py
@@ -13,7 +13,7 @@ import sklearn.decomposition
 from meica.t2smap import (optcom, t2sadmap)
 from meica.utils import (cat2echos, uncat2echos, makemask,
                          makeadmask, fmask, unmask,
-                         fitgaussian, niwrite)
+                         fitgaussian, niwrite, dice, andb)
 
 
 """
@@ -71,16 +71,6 @@ def do_svm(train_set, train_labs,
     return pred_labels, clf
 
 
-def dice(A,B):
-    denom = np.array(A!=0,dtype=np.int).sum(0)+(np.array(B!=0,dtype=np.int).sum(0))
-    if denom!=0:
-        AB_un = andb([A!=0,B!=0])==2
-        numer = np.array(AB_un,dtype=np.int).sum(0)
-        return 2.*numer/denom
-    else:
-        return 0.
-
-
 def spatclust(data,mask,csize,thr,header,aff,infile=None,dindex=0,tindex=0):
     if infile==None:
         data = data.copy()
@@ -128,13 +118,6 @@ def get_coeffs(data,mask,X,add_const=False):
     out = unmask(tmpbetas,mask)
 
     return out
-
-
-def andb(arrs):
-    result = np.zeros(arrs[0].shape)
-    for aa in arrs:
-        result += np.array(aa, dtype=np.int)
-    return result
 
 
 def getelbow_cons(ks,val=False):

--- a/meica/tedana.py
+++ b/meica/tedana.py
@@ -1,19 +1,19 @@
-#!/usr/bin/env python
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
 
 import os
 import sys
 import gzip
 import pickle
-import argparse
 import numpy as np
 import nibabel as nib
 from sklearn import svm
 import scipy.stats as stats
 import sklearn.decomposition
-from meica.t2smap import (optcom, t2sadmap)
-from meica.utils import (cat2echos, uncat2echos, makemask,
-                         makeadmask, fmask, unmask,
-                         fitgaussian, niwrite, dice, andb)
+from .t2smap import (optcom, t2sadmap)
+from .utils import (cat2echos, uncat2echos, makemask,
+                    makeadmask, fmask, unmask,
+                    fitgaussian, niwrite, dice, andb)
 
 
 """
@@ -28,7 +28,7 @@ PROCEDURE 2 : Computes ME-PCA and ME-ICA
 PROCEDURE 2a: Model fitting and component selection routines
 """
 
-F_MAX=500
+F_MAX = 500
 Z_MAX = 8
 
 
@@ -77,6 +77,33 @@ def do_svm(X_train, y_train, X_test, svmtype=0):
 def spatclust(data, mask, csize, thr, header, aff, infile=None, dindex=0,
               tindex=0):
     """
+
+    Parameters
+    ----------
+    data :
+
+    mask :
+
+    csize :
+
+    thr :
+
+    header :
+
+    aff :
+
+    infile :
+
+    dindex :
+
+    tindex :
+
+
+    Returns
+    -------
+    clustered :
+
+
     """
     if infile is None:
         data = data.copy()
@@ -87,8 +114,10 @@ def spatclust(data, mask, csize, thr, header, aff, infile=None, dindex=0,
     if data is not None and len(np.squeeze(data).shape) > 1 and dindex + tindex == 0:
         addopts = '-doall'
     else:
-        addopts = '-1dindex %s -1tindex %s' % (str(dindex), str(tindex))
-    os.system('3dmerge -overwrite %s -dxyz=1  -1clust 1 %i -1thresh %.02f -prefix __clout.nii.gz %s' % (addopts, int(csize), float(thr), infile))
+        addopts = '-1dindex {0} -1tindex {1}'.format(str(dindex), str(tindex))
+
+    cmd_str = '3dmerge -overwrite {0} -dxyz=1  -1clust 1 {1:d} -1thresh {2:.02f} -prefix __clout.nii.gz {3}'
+    os.system(cmd_str.format(addopts, int(csize), float(thr), infile))
     clustered = fmask(nib.load('__clout.nii.gz').get_data(), mask) != 0
     return clustered
 
@@ -124,84 +153,156 @@ def get_coeffs(data, mask, X, add_const=False):
     """
     get_coeffs(data,X)
 
-    Input:
+    Parameters
+    ----------
+    data : array-like
+        Array of shape (nx, ny, nz, nt)
+    mask : array-like
+        Array of shape (nx, ny, nz)
+    X : array-like
+        Array of shape (nt, nc)
+    add_const : bool, optional
+        Default is False.
 
-    data has shape (nx,ny,nz,nt)
-    mask has shape (nx,ny,nz)
-    X    has shape (nt,nc)
-
-    Output:
-
-    out  has shape (nx,ny,nz,nc)
+    Returns
+    -------
+    out : array_like
+        Array of shape (nx, ny, nz, nc)
     """
-    mdata = fmask(data,mask).transpose()
+    mdata = fmask(data, mask).transpose()
 
-    X=np.atleast_2d(X)
-    if X.shape[0]==1: X=X.T
+    # Coerce X to >=2d
+    X = np.atleast_2d(X)
+
+    if X.shape[0] == 1:
+        X = X.T
     Xones = np.atleast_2d(np.ones(np.min(mdata.shape))).T
-    if add_const: X = np.hstack([X,Xones])
+    if add_const:
+        X = np.hstack([X, Xones])
 
-    tmpbetas = np.linalg.lstsq(X,mdata)[0].transpose()
-    if add_const: tmpbetas = tmpbetas[:,:-1]
-    out = unmask(tmpbetas,mask)
+    tmpbetas = np.linalg.lstsq(X, mdata)[0].transpose()
+    if add_const:
+        tmpbetas = tmpbetas[:, :-1]
+    out = unmask(tmpbetas, mask)
 
     return out
 
 
-def getelbow_cons(ks,val=False):
-    #Elbow using mean/variance method - conservative
+def getelbow_cons(ks, val=False):
+    """Elbow using mean/variance method - conservative
+
+    Parameters
+    ----------
+    ks : array-like
+
+    val : bool, optional
+        Default is False
+
+    Returns
+    -------
+    array-like
+        Either the elbow index (if val is True) or the values at the elbow
+        index (if val is False)
+    """
     ks = np.sort(ks)[::-1]
     nk = len(ks)
-    ds = np.array([  (ks[nk-5-ii-1]>ks[nk-5-ii:nk].mean()+2*ks[nk-5-ii:nk].std()) for ii in range(nk-5) ][::-1],dtype=np.int)
+    temp1 = [(ks[nk-5-ii-1] > ks[nk-5-ii:nk].mean() + 2*ks[nk-5-ii:nk].std()) for ii in range(nk-5)]
+    ds = np.array(temp1[::-1], dtype=np.int)
     dsum = []
     c_ = 0
     for d_ in ds:
-        c_=(c_+d_)*d_
+        c_ = (c_ + d_) * d_
         dsum.append(c_)
-    e2=np.argmax(np.array(dsum))
-    elind = np.max([getelbow_mod(ks),e2])
+    e2 = np.argmax(np.array(dsum))
+    elind = np.max([getelbow_mod(ks), e2])
+
     if val: return ks[elind]
     else: return elind
 
 
-def getelbow_mod(ks,val=False):
-    #Elbow using linear projection method - moderate
+def getelbow_mod(ks, val=False):
+    """Elbow using linear projection method - moderate
+
+    Parameters
+    ----------
+    ks : array-like
+
+    val : bool, optional
+        Default is False
+
+    Returns
+    -------
+    array-like
+        Either the elbow index (if val is True) or the values at the elbow
+        index (if val is False)
+    """
     ks = np.sort(ks)[::-1]
     nc = ks.shape[0]
-    coords = np.array([np.arange(nc),ks])
-    p  = coords - np.tile(np.reshape(coords[:,0],(2,1)),(1,nc))
-    b  = p[:,-1]
-    b_hat = np.reshape(b/np.sqrt((b**2).sum()),(2,1))
-    proj_p_b = p - np.dot(b_hat.T,p)*np.tile(b_hat,(1,nc))
-    d = np.sqrt((proj_p_b**2).sum(axis=0))
+    coords = np.array([np.arange(nc), ks])
+    p  = coords - np.tile(np.reshape(coords[:, 0], (2, 1)), (1, nc))
+    b  = p[:, -1]
+    b_hat = np.reshape(b / np.sqrt((b ** 2).sum()), (2, 1))
+    proj_p_b = p - np.dot(b_hat.T, p) * np.tile(b_hat, (1, nc))
+    d = np.sqrt((proj_p_b ** 2).sum(axis=0))
     k_min_ind = d.argmax()
     k_min  = ks[k_min_ind]
+
     if val: return ks[k_min_ind]
     else: return k_min_ind
 
 
-def getelbow_aggr(ks,val=False):
-    #Elbow using curvature - aggressive
+def getelbow_aggr(ks, val=False):
+    """Elbow using curvature - aggressive
+
+    Parameters
+    ----------
+    ks : array-like
+
+    val : bool, optional
+        Default is False
+
+    Returns
+    -------
+    array-like
+        Either the elbow index (if val is True) or the values at the elbow
+        index (if val is False)
+    """
     ks = np.sort(ks)[::-1]
-    dKdt = ks[:-1]-ks[1:]
-    dKdt2 = dKdt[:-1]-dKdt[1:]
-    curv = np.abs((dKdt2/(1+dKdt[:-1]**2.)**(3./2.)))
-    curv[np.isnan(curv)]=-1*10**6
-    maxcurv = np.argmax(curv)+2
+    dKdt = ks[:-1] - ks[1:]
+    dKdt2 = dKdt[:-1] - dKdt[1:]
+    curv = np.abs((dKdt2 / (1 + dKdt[:-1]**2.) ** (3. / 2.)))
+    curv[np.isnan(curv)] = -1 * 10**6
+    maxcurv = np.argmax(curv) + 2
+
     if val: return(ks[maxcurv])
     else:return maxcurv
 
 
 def getfbounds(ne):
-    F05s=[None,None,18.5,10.1,7.7,6.6,6.0,5.6,5.3,5.1,5.0]
-    F025s=[None,None,38.5,17.4,12.2,10,8.8,8.1,7.6,7.2,6.9]
-    F01s=[None,None,98.5,34.1,21.2,16.2,13.8,12.2,11.3,10.7,10.]
-    return F05s[ne-1],F025s[ne-1],F01s[ne-1]
+    """
+
+    Parameters
+    ----------
+    ne : int
+        Number of echoes.
+
+    Returns
+    -------
+    """
+    if not isinstance(ne, int):
+        raise IOError('Input ne must be int')
+    elif ne > 0:
+        raise ValueError('Input ne must be greater than 0')
+
+    F05s = [None, 18.5, 10.1, 7.7, 6.6, 6.0, 5.6, 5.3, 5.1, 5.0]
+    F025s = [None, 38.5, 17.4, 12.2, 10, 8.8, 8.1, 7.6, 7.2, 6.9]
+    F01s = [None, 98.5, 34.1, 21.2, 16.2, 13.8, 12.2, 11.3, 10.7, 10.]
+    return F05s[ne], F025s[ne], F01s[ne]
 
 
-def eimask(dd,ees=None):
+def eimask(dd, ees=None):
     if ees==None: ees=range(dd.shape[1])
-    imask = np.zeros([dd.shape[0],len(ees)])
+    imask = np.zeros([dd.shape[0], len(ees)])
     for ee in ees:
         print(ee)
         lthr = 0.001 * stats.scoreatpercentile(dd[:,ee,:].flatten(),98, interpolation_method='lower')
@@ -1144,137 +1245,31 @@ def writeresults_echoes(acc, rej, midk, head):
         write_split_ts(catd[:,:,:,ii,:],comptable, mmix,acc, rej, midk, head, suffix = 'e%i' % (ii+1))
 
 
-def get_parser():
+def main(options):
     """
-    Parses command line inputs for tedana
-    Returns
-    -------
-    parser.parse_args() : argparse dic
-    """
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-d',
-                        dest='data',
-                        nargs='+',
-                        help="Spatially Concatenated Multi-Echo Dataset",
-                        required=True)
-    parser.add_argument('-e',
-                        dest='tes',
-                        nargs='+',
-                        help="Echo times (in ms) ex: 15,39,63",
-                        required=True)
-    parser.add_argument("--mix",
-                        dest='mixm',
-                        help="Mixing matrix. If not provided, " +
-                             "ME-PCA & ME-ICA is done.",
-                        default=None)
-    parser.add_argument("--ctab",
-                        dest='ctab',
-                        help="Component table extract pre-computed " +
-                             "classifications from.",
-                        default=None)
-    parser.add_argument("--manacc",
-                        dest='manacc',
-                        help="Comma separated list of manually " +
-                             "accepted components",
-                        default=None)
-    parser.add_argument("--strict",
-                        dest='strict',
-                        action='store_true',
-                        help="Ignore low-variance ambiguous components",
-                        default=False)
-    # parser.add_argument("--wav",
-    #                     dest='wav',
-    #                     help="Perform wavelet PCA, default False",
-    #                     default=False)
-    parser.add_argument("--no_gscontrol",
-                        dest='no_gscontrol',
-                        action='store_true',
-                        help="Control global signal using spatial approach",
-                        default=False)
-    parser.add_argument("--kdaw",
-                        dest='kdaw',
-                        help="Dimensionality augmentation weight " +
-                             "(Kappa). Default 10. -1 for low-dimensional ICA",
-                        default=10.)
-    parser.add_argument("--rdaw",
-                        dest='rdaw',
-                        help="Dimensionality augmentation weight (Rho). " +
-                             "Default 1. -1 for low-dimensional ICA",
-                        default=1.)
-    parser.add_argument("--conv",
-                        dest='conv',
-                        help="Convergence limit. Default 2.5e-5",
-                        default='2.5e-5')
-    parser.add_argument("--sourceTEs",
-                        dest='ste',
-                        help="Source TEs for models. ex: -ste 0 for all, " +
-                             "-1 for opt. com. Default -1.",
-                        default=-1)
-    parser.add_argument("--combmode",
-                        dest='combmode',
-                        help="Combination scheme for TEs: t2s " +
-                             "(Posse 1999, default),ste(Poser)",
-                        default='t2s')
-    parser.add_argument("--denoiseTEs",
-                        dest='dne',
-                        action='store_true',
-                        help="Denoise each TE dataset separately",
-                        default=False)
-    parser.add_argument("--initcost",
-                        dest='initcost',
-                        help="Initial cost func. for ICA: pow3, " +
-                             "tanh(default), gaus, skew",
-                        default='tanh')
-    parser.add_argument("--finalcost",
-                        dest='finalcost',
-                        help="Final cost func, same opts. as initial",
-                        default='tanh')
-    parser.add_argument("--stabilize",
-                        dest='stabilize',
-                        action='store_true',
-                        help="Stabilize convergence by reducing " +
-                             "dimensionality, for low quality data",
-                        default=False)
-    parser.add_argument("--fout",
-                        dest='fout',
-                        help="Output TE-dependence Kappa/Rho SPMs",
-                        action="store_true",
-                        default=False)
-    parser.add_argument("--filecsdata",
-                        dest='filecsdata',
-                        help="Save component selection data",
-                        action="store_true",
-                        default=False)
-    parser.add_argument("--label",
-                        dest='label',
-                        help="Label for output directory.",
-                        default=None)
-    parser.add_argument("--seed",
-                        dest='fixed_seed',
-                        help="Seeded value for ICA, for reproducibility.",
-                        default=42)
-    return parser
 
-
-def main(*args):
+    Args (and defaults):
+    data, tes, mixm=None, ctab=None, manacc=None, strict=False,
+             no_gscontrol=False, kdaw=10., rdaw=1., conv=2.5e-5, ste=-1,
+             combmode='t2s', dne=False, initcost='tanh', finalcost='tanh',
+             stabilize=False, fout=False, filecsdata=False, label=None,
+             fixed_seed=42
     """
-    """
-    options = get_parser().parse_args(*args)
     global tes, ne, catd, head, aff
     tes = [float(te) for te in options.tes]
     ne = len(tes)
     catim  = nib.load(options.data[0])
 
-    head   = catim.get_header()
+    head = catim.get_header()
     head.extensions = []
     head.set_sform(head.get_sform(),code=1)
     aff = catim.get_affine()
     catd = cat2echos(catim.get_data(),ne)
     nx,ny,nz,Ne,nt = catd.shape
-    mu  = catd.mean(axis=-1)
-    sig  = catd.std(axis=-1)
+    mu = catd.mean(axis=-1)
+    sig = catd.std(axis=-1)
 
-    """Parse options, prepare output directory"""
+    #Parse options, prepare output directory
     if options.fout: options.fout = aff
     else: options.fout=None
 
@@ -1359,6 +1354,3 @@ def main(*args):
     writeresults(OCcatd, comptable, mmix, nt, acc, rej, midk, empty, head)
     gscontrol_mmix(mmix, acc, rej, midk, empty, head)
     if options.dne: writeresults_echoes(acc, rej, midk, head)
-
-if __name__ == '__main__':
-    main()

--- a/meica/tedana.py
+++ b/meica/tedana.py
@@ -884,22 +884,22 @@ def tedpca(combmode, mask, stabilize, head, ste=0, mlepca=True):
     if int(kdaw)!=-1 and int(rdaw)==-1:
         rhos_lim = rhos[andb([rhos<fmid,rhos>fmin])==2]
         rho_thr = rhos_lim[getelbow_mod(rhos_lim)]
+
+    temp1 = np.array(ctb[:, 1] > kappa_thr, dtype=np.int)
+    temp2 = np.array(ctb[:, 2] > rho_thr, dtype=np.int)
+    temp3 = np.array(ctb[:, 3] > eigelb, dtype=np.int)
+    temp4 = np.array(ctb[:, 3] > spmin, dtype=np.int)
+    temp5 = np.array(ctb[:, 1] != F_MAX, dtype=np.int)
+    temp6 = np.array(ctb[:, 2] != F_MAX, dtype=np.int)
+    pcscore = (temp1 + temp2 + temp3) * temp4 * temp5 * temp6
     if stabilize:
-        pcscore = (np.array(ctb[:,1]>kappa_thr,dtype=np.int)+np.array(ctb[:,2]>rho_thr,dtype=np.int)+np.array(ctb[:,3]>eigelb,dtype=np.int))*np.array(ctb[:,3]>spmin,dtype=np.int)*np.array(spcum<0.95,dtype=np.int)*np.array(ctb[:,2]>fmin,dtype=np.int)*np.array(ctb[:,1]>fmin,dtype=np.int)*np.array(ctb[:,1]!=F_MAX,dtype=np.int)*np.array(ctb[:,2]!=F_MAX,dtype=np.int)
-    else:
-        pcscore = (np.array(ctb[:,1]>kappa_thr,dtype=np.int)+np.array(ctb[:,2]>rho_thr,dtype=np.int)+np.array(ctb[:,3]>eigelb,dtype=np.int))*np.array(ctb[:,3]>spmin,dtype=np.int)*np.array(ctb[:,1]!=F_MAX,dtype=np.int)*np.array(ctb[:,2]!=F_MAX,dtype=np.int)
+        temp7 = np.array(spcum < 0.95, dtype=np.int)
+        temp8 = np.array(ctb[:, 2] > fmin, dtype=np.int)
+        temp9 = np.array(ctb[:, 1] > fmin, dtype=np.int)
+        pcscore = pcscore * temp7 * temp8 * temp9
+
     pcsel = pcscore > 0
     pcrej = np.array(pcscore==0,dtype=np.int)*np.array(ctb[:,3]>spmin,dtype=np.int) > 0
-
-    """
-    kdaw=15
-    rdaw=5
-    kappa_thr = np.average(sorted([fmin,getelbow_mod(kappas,True)/2,fmid]),weights=[kdaw,1,1])
-    rho_thr = np.average(sorted([fmin,getelbow_cons(rhos,True)/2,fmid]),weights=[rdaw,1,1])
-    print kappa_thr, rho_thr
-    pcscore = (np.array(ctb[:,1]>kappa_thr,dtype=np.int)+np.array(ctb[:,2]>rho_thr,dtype=np.int)+np.array(ctb[:,3]>eigelb,dtype=np.int))*np.array(ctb[:,3]>spmin,dtype=np.int)*np.array(ctb[:,1]!=F_MAX,dtype=np.int)*np.array(ctb[:,2]!=F_MAX,dtype=np.int)
-    np.array(pcscore>0).sum()
-    """
 
     dd = u.dot(np.diag(s*np.array(pcsel,dtype=np.int))).dot(v)
 
@@ -1329,5 +1329,5 @@ def main(*args):
     gscontrol_mmix(mmix, acc, rej, midk, empty, head)
     if options.dne: writeresults_echoes(acc, rej, midk, head)
 
-if __name__=='__main__':
+if __name__ == '__main__':
     main()

--- a/meica/tests/test_tedana.py
+++ b/meica/tests/test_tedana.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+"""
+Tests for tedana.
+"""
+
+TEST_FILE = 'https://www.dropbox.com/s/ljeqskdmnc6si9d/zcat_ffd.nii.gz?dl=0'

--- a/meica/utils.py
+++ b/meica/utils.py
@@ -1,23 +1,27 @@
+"""Utilities for meica package.
+"""
 import numpy as np
 import nibabel as nib
 from scipy.optimize import leastsq
 from scipy.stats import scoreatpercentile
 
+from meica.due import due, BibTeX
 
-def cat2echos(data,Ne):
+
+def cat2echos(data, Ne):
     """
     cat2echos(data,Ne)
 
     Input:
     data shape is (nx,ny,Ne*nz,nt)
     """
-    nx,ny = data.shape[0:2]
-    nz = data.shape[2]//Ne
-    if len(data.shape) >3:
+    nx, ny = data.shape[0:2]
+    nz = data.shape[2] // Ne
+    if len(data.shape) > 3:
         nt = data.shape[3]
     else:
         nt = 1
-    return np.reshape(data,(nx,ny,nz,Ne,nt),order='F')
+    return np.reshape(data, (nx, ny, nz, Ne, nt), order='F')
 
 
 def uncat2echos(data,Ne):
@@ -27,61 +31,72 @@ def uncat2echos(data,Ne):
     Input:
     data shape is (nx,ny,Ne,nz,nt)
     """
-    nx,ny = data.shape[0:2]
+    nx, ny = data.shape[0:2]
     nz = data.shape[2]*Ne
-    if len(data.shape) >4:
+    if len(data.shape) > 4:
         nt = data.shape[4]
     else:
         nt = 1
-    return np.reshape(data,(nx,ny,nz,nt),order='F')
+    return np.reshape(data, (nx, ny, nz, nt), order='F')
 
 
 def makemask(cdat):
+    """
+    Create a mask.
+    """
+    nx, ny, nz, Ne, nt = cdat.shape
 
-    nx,ny,nz,Ne,nt = cdat.shape
-
-    mask = np.ones((nx,ny,nz),dtype=np.bool)
+    mask = np.ones((nx, ny, nz), dtype=np.bool)
 
     for i in range(Ne):
-        tmpmask = (cdat[:,:,:,i,:] != 0).prod(axis=-1,dtype=np.bool)
+        tmpmask = (cdat[:, :, :, i, :] != 0).prod(axis=-1, dtype=np.bool)
         mask = mask & tmpmask
 
     return mask
 
 
-def makeadmask(cdat,min=True,getsum=False):
+def makeadmask(cdat, min=True, getsum=False):
+    """
+    Create a mask.
 
-    nx,ny,nz,Ne,nt = cdat.shape
+    NOTES:
+      - Need to change arg `min` to non-built-in.
+      - Is `cdat[:, :, :, :, :]` necessary? Why not just `cdat`?
+    """
+    #nx, ny, nz, Ne, nt = cdat.shape  # nt was unused
+    nx, ny, nz, Ne, _ = cdat.shape
 
-    mask = np.ones((nx,ny,nz),dtype=np.bool)
+    mask = np.ones((nx, ny, nz), dtype=np.bool)
 
     if min:
-        mask = cdat[:,:,:,:,:].prod(axis=-1).prod(-1)!=0
+        mask = cdat[:, :, :, :, :].prod(axis=-1).prod(-1) != 0
         return mask
     else:
         #Make a map of longest echo that a voxel can be sampled with,
         #with minimum value of map as X value of voxel that has median
         #value in the 1st echo. N.b. larger factor leads to bias to lower TEs
-        emeans = cdat[:,:,:,:,:].mean(-1)
-        medv = emeans[:,:,:,0] == scoreatpercentile(emeans[:,:,:,0][emeans[:,:,:,0]!=0],33,interpolation_method='higher')
-        lthrs = np.squeeze(np.array([ emeans[:,:,:,ee][medv]/3 for ee in range(Ne) ]))
+        emeans = cdat[:, :, :, :, :].mean(-1)
+        medv = emeans[:, :, :, 0] == scoreatpercentile(emeans[:, :, :, 0][emeans[:, :, :, 0] != 0],
+                                                       33, interpolation_method='higher')
+        lthrs = np.squeeze(np.array([emeans[:, :, :, ee][medv] / 3 for ee in range(Ne)]))
 
-        if len(lthrs.shape)==1:
+        if len(lthrs.shape) == 1:
             lthrs = np.atleast_2d(lthrs).T
-        lthrs = lthrs[:,lthrs.sum(0).argmax()]
+        lthrs = lthrs[:, lthrs.sum(0).argmax()]
 
-        mthr = np.ones([nx,ny,nz,Ne])
-        for ee in range(Ne): mthr[:,:,:,ee]*=lthrs[ee]
-        mthr = np.abs(emeans[:,:,:,:])>mthr
-        masksum = np.array(mthr,dtype=np.int).sum(-1)
-        mask = masksum!=0
+        mthr = np.ones([nx, ny, nz, Ne])
+        for i_echo in range(Ne):
+            mthr[:, :, :, i_echo] *= lthrs[i_echo]
+        mthr = np.abs(emeans[:, :, :, :]) > mthr
+        masksum = np.array(mthr, dtype=np.int).sum(-1)
+        mask = masksum != 0
         if getsum:
-            return mask,masksum
+            return mask, masksum
         else:
             return mask
 
 
-def fmask(data,mask):
+def fmask(data, mask):
     """
     fmask(data,mask)
 
@@ -94,22 +109,22 @@ def fmask(data,mask):
     """
 
     s = data.shape
-    sm = mask.shape
+    #sm = mask.shape  # unused
 
-    N = s[0]*s[1]*s[2]
+    N = s[0] * s[1] * s[2]
     news = []
     news.append(N)
 
-    if len(s) >3:
+    if len(s) > 3:
         news.extend(s[3:])
 
-    tmp1 = np.reshape(data,news)
-    fdata = tmp1.compress((mask > 0 ).ravel(),axis=0)
+    tmp1 = np.reshape(data, news)
+    fdata = tmp1.compress((mask > 0).ravel(), axis=0)
 
     return fdata.squeeze()
 
 
-def unmask (data,mask):
+def unmask (data, mask):
     """
     unmask (data,mask)
 
@@ -122,17 +137,17 @@ def unmask (data,mask):
     M = (mask != 0).ravel()
     Nm = M.sum()
 
-    nx,ny,nz = mask.shape
+    nx, ny, nz = mask.shape
 
     if len(data.shape) > 1:
         nt = data.shape[1]
     else:
         nt = 1
 
-    out = np.zeros((nx*ny*nz,nt),dtype=data.dtype)
-    out[M,:] = np.reshape(data,(Nm,nt))
+    out = np.zeros((nx * ny * nz, nt), dtype=data.dtype)
+    out[M, :] = np.reshape(data, (Nm, nt))
 
-    return np.squeeze(np.reshape(out,(nx,ny,nz,nt)))
+    return np.squeeze(np.reshape(out, (nx, ny, nz, nt)))
 
 def moments(data):
     """
@@ -144,18 +159,17 @@ def moments(data):
     """
     total = data.sum()
     X, Y = np.indices(data.shape)
-    center_x = (X*data).sum()/total
-    center_y = (Y*data).sum()/total
+    center_x = (X * data).sum() / total
+    center_y = (Y * data).sum() / total
     col = data[:, int(center_y)]
-    width_x = np.sqrt(abs((np.arange(col.size)-center_y)**2*col).sum()/col.sum())
+    width_x = np.sqrt(abs((np.arange(col.size) - center_y)**2 * col).sum() / col.sum())
     row = data[int(center_x), :]
-    width_y = np.sqrt(abs((np.arange(row.size)-center_x)**2*row).sum()/row.sum())
+    width_y = np.sqrt(abs((np.arange(row.size) - center_x)**2 * row).sum() / row.sum())
     height = data.max()
     return height, center_x, center_y, width_x, width_y
 
 
-def gaussian(height, center_x, center_y,
-             width_x, width_y):
+def gaussian(height, center_x, center_y, width_x, width_y):
     """
     Returns a gaussian function with the given parameters
 
@@ -164,7 +178,7 @@ def gaussian(height, center_x, center_y,
     """
     width_x = float(width_x)
     width_y = float(width_y)
-    return lambda x,y: height*np.exp(-(((center_x-x)/width_x)**2+((center_y-y)/width_y)**2)/2)
+    return lambda x, y: height * np.exp(-(((center_x - x) / width_x)**2 + ((center_y - y) / width_y)**2) / 2)
 
 
 def fitgaussian(data):
@@ -177,18 +191,82 @@ def fitgaussian(data):
     """
     params = moments(data)
     errorfunction = lambda p, data: np.ravel(gaussian(*p)(*np.indices(data.shape)) - data)
-    (p, success) = leastsq(errorfunction, params, data)
+    (p, _) = leastsq(errorfunction, params, data)
     return p
 
 
 def niwrite(data, affine, name, head, header=None):
-    data[np.isnan(data)]=0
-    if header == None:
+    """
+    Write out nifti file.
+    """
+    data[np.isnan(data)] = 0
+    if header is None:
         this_header = head.copy()
         this_header.set_data_shape(list(data.shape))
     else:
         this_header = header
 
-    outni = nib.Nifti1Image(data,affine,header=this_header)
+    outni = nib.Nifti1Image(data, affine, header=this_header)
     outni.set_data_dtype('float64')
     outni.to_filename(name)
+
+
+@due.dcite(BibTeX('@article{dice1945measures,'\
+            	  'author={Dice, Lee R},'\
+            	  'title={Measures of the amount of ecologic association between species},'\
+            	  'year = {1945},'\
+            	  'publisher = {Wiley Online Library},'\
+            	  'journal = {Ecology},'\
+                  'volume={26},'\
+                  'number={3},'\
+                  'pages={297--302}}'),
+           description='Introduction of Sorenson-Dice index by Dice in 1945.')
+@due.dcite(BibTeX('@article{sorensen1948method,'\
+            	  'author={S{\\o}rensen, Thorvald},'\
+            	  'title={A method of establishing groups of equal amplitude '\
+                  'in plant sociology based on similarity of species and its '\
+                  'application to analyses of the vegetation on Danish commons},'\
+            	  'year = {1948},'\
+            	  'publisher = {Wiley Online Library},'\
+            	  'journal = {Biol. Skr.},'\
+                  'volume={5},'\
+                  'pages={1--34}}'),
+           description='Introduction of Sorenson-Dice index by Sorenson in 1948.')
+def dice(arr1, arr2):
+    """Compute Dice's similarity index between two numpy arrays. Arrays will be
+    binarized before comparison.
+    From https://gist.github.com/brunodoamaral/e130b4e97aa4ebc468225b7ce39b3137
+
+    Parameters
+    ----------
+    arr1, arr2 : array_like
+        Input arrays, arrays to binarize and compare.
+
+    Returns
+    -------
+    dsi : float
+        Dice-Sorenson index.
+    """
+    arr1 = np.array(arr1 != 0).astype(int)
+    arr2 = np.array(arr2 != 0).astype(int)
+
+    if arr1.shape != arr2.shape:
+        raise ValueError('Shape mismatch: arr1 and arr2 must have the same shape.')
+
+    arr_sum = arr1.sum() + arr2.sum()
+    if arr_sum == 0:
+        dsi = 0
+    else:
+        intersection = np.logical_and(arr1, arr2)
+        dsi = (2. * intersection.sum()) / arr_sum
+
+    return dsi
+
+
+def andb(arrs):
+    """Add multiple 1d arrays together.
+    """
+    result = np.zeros(arrs[0].shape)
+    for aa in arrs:
+        result += np.array(aa, dtype=np.int)
+    return result

--- a/meica/utils.py
+++ b/meica/utils.py
@@ -5,7 +5,7 @@ import nibabel as nib
 from scipy.optimize import leastsq
 from scipy.stats import scoreatpercentile
 
-from meica.due import due, BibTeX
+from .due import due, BibTeX
 
 
 def cat2echos(data, Ne):
@@ -24,7 +24,7 @@ def cat2echos(data, Ne):
     return np.reshape(data, (nx, ny, nz, Ne, nt), order='F')
 
 
-def uncat2echos(data,Ne):
+def uncat2echos(data, Ne):
     """
     uncat2echos(data,Ne)
 
@@ -124,7 +124,7 @@ def fmask(data, mask):
     return fdata.squeeze()
 
 
-def unmask (data, mask):
+def unmask(data, mask):
     """
     unmask (data,mask)
 
@@ -239,7 +239,7 @@ def dice(arr1, arr2):
 
     Parameters
     ----------
-    arr1, arr2 : array_like
+    arr1, arr2 : array-like
         Input arrays, arrays to binarize and compare.
 
     Returns
@@ -264,9 +264,17 @@ def dice(arr1, arr2):
 
 
 def andb(arrs):
-    """Add multiple 1d arrays together.
+    """Add multiple arrays of ints or bools together.
     """
+    same_shape = []
+    for arr in arrs:
+        for arr2 in arrs:
+            same_shape.append(arr.shape == arr2.shape)
+
+    if not np.all(same_shape):
+        raise ValueError('All input arrays must have same shape')
+
     result = np.zeros(arrs[0].shape)
-    for aa in arrs:
-        result += np.array(aa, dtype=np.int)
+    for arr in arrs:
+        result += np.array(arr, dtype=np.int)
     return result

--- a/meica/version.py
+++ b/meica/version.py
@@ -1,0 +1,7 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+
+"""Specifies current version of meica to be used by setup.py and __init__.py
+"""
+
+__version__ = '3.2.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 mdp
-nibabel 
+nibabel
 nipype
 numpy >= 1.5
 scikit-learn >= 0.15.1
 scipy >= 0.11
 sphinx-argparse
+duecredit

--- a/scripts/run_alignp_mepi_anat.py
+++ b/scripts/run_alignp_mepi_anat.py
@@ -1,0 +1,90 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+import argparse
+
+from meica import alignp_mepi_anat as ama
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+
+    # Base processing options
+    parser.add_argument('-e',
+                        dest='tes',
+                        nargs='+',
+                        help="Echo times in ms. ex: -e 14.5 38.5 62.5",
+                        required=True)
+    parser.add_argument('-t',
+                        dest='t2s',
+                        help='T2* volume',
+                        default='')
+    parser.add_argument('-s',
+                        dest='s0',
+                        help="Skull-stripped S0 weighted volume, optional, for masking T2*",
+                        default='')
+    parser.add_argument('-a',
+                        dest='anat',
+                        help="Anatomical volume",
+                        default='')
+    parser.add_argument('-p',
+                        dest='prefix',
+                        help="Alignment matrix prefix",
+                        default='')
+    parser.add_argument("--cmass",
+                        action='store_true',
+                        dest='cmass',
+                        help="Align cmass before main co-registration",
+                        default=False)
+    parser.add_argument("--autocmass",
+                        action='store_false',
+                        dest='autocmass',
+                        help="Automatic cmass detection (default yes)",
+                        default=True)
+    parser.add_argument("--maxrot",
+                        dest='maxrot',
+                        help="Maximum rotation, default 30",
+                        default='30')
+    parser.add_argument("--maxshift",
+                        dest='maxshf',
+                        help="Maximum shift, default 30",
+                        default='30')
+    parser.add_argument("--maxscl",
+                        dest='maxscl',
+                        help="Maximum scale, default 1.01",
+                        default='1.01')
+
+    return parser
+
+
+def main(argv=None):
+    parser = get_parser()
+    options = parser.parse_args(argv)
+
+    #Set up and cd into directory
+    sl = []
+    walignp_dirname = "alignp.%s" % (options.prefix)
+    sl.append("rm -rf %s " % walignp_dirname)
+    sl.append("mkdir %s " % walignp_dirname)
+    sl.append("cd %s " % walignp_dirname)
+
+    #Import datasets
+    t2s_name, s0_name, anat_name = ama.import_datasets([options.t2s, options.s0, options.anat])
+
+    #Filter and segment T2* volume to produce T2* base and weight volumes
+    basevol, weightvol = ama.graywt(t2s_name, s0_name)
+
+    #Run 3dAllineate
+    allin_volume, _ = ama.allineate(anat_name, weightvol, basevol,
+                                    options.prefix, options.maxrot,
+                                    options.maxshf, options.maxscl,
+                                    options.cmass)
+
+    #For auto center-of-mass, check dice of COM and no-COM options
+    ama.cmselect(basevol, allin_volume)
+
+    #Run procedure
+    ama.runproc(options.prefix, sl)
+
+
+if __name__=='__main__':
+    main()

--- a/scripts/run_alignp_mepi_anat.py
+++ b/scripts/run_alignp_mepi_anat.py
@@ -12,7 +12,7 @@ def get_parser():
     parser.add_argument('-e',
                         dest='tes',
                         nargs='+',
-                        help="Echo times in ms. ex: -e 14.5 38.5 62.5",
+                        help='Echo times in ms. ex: -e 14.5 38.5 62.5',
                         required=True)
     parser.add_argument('-t',
                         dest='t2s',
@@ -20,37 +20,37 @@ def get_parser():
                         default='')
     parser.add_argument('-s',
                         dest='s0',
-                        help="Skull-stripped S0 weighted volume, optional, for masking T2*",
+                        help='Skull-stripped S0 weighted volume, optional, for masking T2*',
                         default='')
     parser.add_argument('-a',
                         dest='anat',
-                        help="Anatomical volume",
+                        help='Anatomical volume',
                         default='')
     parser.add_argument('-p',
                         dest='prefix',
-                        help="Alignment matrix prefix",
+                        help='Alignment matrix prefix',
                         default='')
-    parser.add_argument("--cmass",
+    parser.add_argument('--cmass',
                         action='store_true',
                         dest='cmass',
-                        help="Align cmass before main co-registration",
+                        help='Align cmass before main co-registration',
                         default=False)
-    parser.add_argument("--autocmass",
+    parser.add_argument('--autocmass',
                         action='store_false',
                         dest='autocmass',
-                        help="Automatic cmass detection (default yes)",
+                        help='Automatic cmass detection (default yes)',
                         default=True)
-    parser.add_argument("--maxrot",
+    parser.add_argument('--maxrot',
                         dest='maxrot',
-                        help="Maximum rotation, default 30",
+                        help='Maximum rotation, default 30',
                         default='30')
-    parser.add_argument("--maxshift",
+    parser.add_argument('--maxshift',
                         dest='maxshf',
-                        help="Maximum shift, default 30",
+                        help='Maximum shift, default 30',
                         default='30')
-    parser.add_argument("--maxscl",
+    parser.add_argument('--maxscl',
                         dest='maxscl',
-                        help="Maximum scale, default 1.01",
+                        help='Maximum scale, default 1.01',
                         default='1.01')
 
     return parser
@@ -62,10 +62,10 @@ def main(argv=None):
 
     #Set up and cd into directory
     sl = []
-    walignp_dirname = "alignp.%s" % (options.prefix)
-    sl.append("rm -rf %s " % walignp_dirname)
-    sl.append("mkdir %s " % walignp_dirname)
-    sl.append("cd %s " % walignp_dirname)
+    walignp_dirname = 'alignp.%s' % (options.prefix)
+    sl.append('rm -rf %s ' % walignp_dirname)
+    sl.append('mkdir %s ' % walignp_dirname)
+    sl.append('cd %s ' % walignp_dirname)
 
     #Import datasets
     t2s_name, s0_name, anat_name = ama.import_datasets([options.t2s, options.s0, options.anat])

--- a/scripts/run_meica.py
+++ b/scripts/run_meica.py
@@ -1,0 +1,248 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+import argparse
+
+from meica import meica
+
+
+def get_parser():
+    """
+    Parses command line inputs
+
+    Returns
+    -------
+    parser.parse_args() : argparse dic
+    """
+
+    # Configure options and help dialog
+    parser = argparse.ArgumentParser()
+
+    # Base processing options
+    parser.add_argument('-e',
+                        dest='tes',
+                        nargs='+',
+                        help="Echo times in ms. ex: -e 14.5 38.5 62.5",
+                        required=True)
+    parser.add_argument('-d',
+                        dest='input_ds',
+                        nargs='+',
+                        help="Input datasets. ex: -d RESTe[123].nii.gz",
+                        required=True)
+    parser.add_argument('-a',
+                        dest='anat',
+                        help="(Optional) anatomical dataset. " +
+                             "ex: -a mprage.nii.gz",
+                        default='')
+    parser.add_argument('-b',
+                        dest='basetime',
+                        help="Time to steady-state equilibration in " +
+                             "seconds(s) or volumes(v). Default 0. ex: -b 4v",
+                        default='0')
+    parser.add_argument('--MNI',
+                        dest='mni',
+                        action='store_true',
+                        help="Warp to MNI standard space.",
+                        default=False)
+    parser.add_argument('--strict',
+                        dest='strict',
+                        action='store_true',
+                        help="Use strict component selection, suitable with" +
+                             " large-voxel, high-SNR data",
+                        default=False)
+
+    # Extended options for processing
+    extopts = parser.add_argument_group("Additional processing options")
+    extopts.add_argument("--qwarp",
+                         dest='qwarp',
+                         action='store_true',
+                         help="Nonlinear warp to standard space using QWarp," +
+                              " requires --MNI or --space).",
+                         default=False)
+    extopts.add_argument("--native",
+                         dest='native',
+                         action='store_true',
+                         help="Output native space results in addition to " +
+                              "standard space results.",
+                         default=False)
+    extopts.add_argument("--space",
+                         dest='space',
+                         help="Path to specific standard space template for " +
+                              "affine anatomical normalization.",
+                         default=False)
+    extopts.add_argument("--fres",
+                         dest='fres',
+                         help="Specify functional voxel dimensions in mm " +
+                              "(iso.) for resampling during preprocessing." +
+                              "ex: --fres=2.5",
+                         default=False)
+    extopts.add_argument("--no_skullstrip",
+                         action="store_true",
+                         dest='no_skullstrip',
+                         help="Anat is intensity-normalized and " +
+                              "skull-stripped (for use with '-a' flag).",
+                         default=False)
+    extopts.add_argument("--no_despike",
+                         action="store_true",
+                         dest='no_despike',
+                         help="Do not de-spike functional data. " +
+                              "Default is to de-spike, recommended.",
+                         default=False)
+    extopts.add_argument("--no_axialize",
+                         action="store_true",
+                         dest='no_axialize',
+                         help="Do not re-write dataset in axial-first order." +
+                              " Default is to axialize, recommended.",
+                         default=False)
+    extopts.add_argument("--mask_mode",
+                         dest='mask_mode',
+                         help="Mask functional with help from anatomical or" +
+                              " standard space images." +
+                              " Options: 'anat' or 'template'.",
+                         default='func')
+    extopts.add_argument("--coreg_mode",
+                         dest='coreg_mode',
+                         help="Coregistration with Local Pearson and T2* weights "+
+                              "(default), or use align_epi_anat.py (edge method)."+
+                              "Options: 'lp-t2s' or 'aea'",
+                         default='lp-t2s')
+    extopts.add_argument("--smooth",
+                         dest='FWHM',
+                         help="FWHM smoothing with 3dBlurInMask. Default none. " +
+                              "ex: --smooth 3mm ",
+                         default='0mm')
+    extopts.add_argument("--align_base",
+                         dest='align_base',
+                         help="Explicitly specify base dataset for volume " +
+                              "registration",
+                         default='')
+    extopts.add_argument("--TR",
+                         dest='TR',
+                         help="TR. Read by default from dataset header",
+                         default='')
+    extopts.add_argument("--tpattern",
+                         dest='tpattern',
+                         help="Slice timing (i.e. alt+z, see 3dTshift -help)." +
+                              " Default from header.",
+                         default='')
+    extopts.add_argument("--align_args",
+                         dest='align_args',
+                         help="Additional arguments to anatomical-functional" +
+                              " co-registration routine",
+                         default='')
+    extopts.add_argument("--ted_args",
+                         dest='ted_args',
+                         help="Additional arguments to " +
+                              "TE-dependence analysis",
+                         default='')
+
+    # Additional, extended preprocessing options
+    #  no help provided, caveat emptor
+    extopts.add_argument("--select_only",
+                         dest='select_only',
+                         action='store_true',
+                         help=argparse.SUPPRESS,
+                         default=False)
+    extopts.add_argument("--tedica_only",
+                         dest='tedica_only',
+                         action='store_true',
+                         help=argparse.SUPPRESS,
+                         default=False)
+    extopts.add_argument("--export_only",
+                         dest='export_only',
+                         action='store_true',
+                         help=argparse.SUPPRESS,
+                         default=False)
+    extopts.add_argument("--daw",
+                         dest='daw',
+                         help=argparse.SUPPRESS,
+                         default='10')
+    extopts.add_argument("--tlrc",
+                         dest='space',
+                         help=argparse.SUPPRESS,
+                         default=False)  # For backwards compat.
+    extopts.add_argument("--highpass",
+                         dest='highpass',
+                         help=argparse.SUPPRESS,
+                         default=0.0)
+    extopts.add_argument("--detrend",
+                         dest='detrend',
+                         help=argparse.SUPPRESS,
+                         default=0.)
+    extopts.add_argument("--initcost",
+                         dest='initcost',
+                         help=argparse.SUPPRESS,
+                         default='tanh')
+    extopts.add_argument("--finalcost",
+                         dest='finalcost',
+                         help=argparse.SUPPRESS,
+                         default='tanh')
+    extopts.add_argument("--sourceTEs",
+                         dest='sourceTEs',
+                         help=argparse.SUPPRESS,
+                         default='-1')
+    parser.add_argument_group(extopts)
+
+    # Extended options for running
+    runopts = parser.add_argument_group("Run options")
+    runopts.add_argument("--prefix",
+                         dest='prefix',
+                         help="Prefix for final ME-ICA output datasets.",
+                         default='')
+    runopts.add_argument("--cpus",
+                         dest='cpus',
+                         help="Maximum number of CPUs (OpenMP threads) to use. " +
+                         "Default 2.",
+                         default='2')
+    runopts.add_argument("--label",
+                         dest='label',
+                         help="Label to tag ME-ICA analysis folder.",
+                         default='')
+    runopts.add_argument("--test_proc",
+                         action="store_true",
+                         dest='test_proc',
+                         help="Align, preprocess 1 dataset then exit.",
+                         default=False)
+    runopts.add_argument("--pp_only",
+                         action="store_true",
+                         dest='preproc_only',
+                         help="Preprocess only, then exit.",
+                         default=False)
+    runopts.add_argument("--keep_int",
+                         action="store_true",
+                         dest='keep_int',
+                         help="Keep preprocessing intermediates. " +
+                              "Default delete.",
+                         default=False)
+    runopts.add_argument("--RESUME",
+                         dest='resume',
+                         action='store_true',
+                         help="Attempt to resume from normalization step " +
+                              "onwards, overwriting existing")
+    runopts.add_argument("--OVERWRITE",
+                         dest='overwrite',
+                         action="store_true",
+                         help="Overwrite existing meica directory.",
+                         default=False)
+    parser.add_argument_group(runopts)
+
+    return parser
+
+
+def main(argv=None):
+    """
+    """
+    parser = get_parser()
+    options = parser.parse_args(argv)
+
+    script_list = meica.gen_script(options)
+
+    setname = meica.get_setname(options.input_ds, options.tes)
+    if options.label != '':
+        setname = setname + options.label
+
+    with open("_meica_{}.sh".format(setname), 'w') as file_object:
+        file_object.write("\n".join(script_list))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/run_meica.py
+++ b/scripts/run_meica.py
@@ -21,207 +21,207 @@ def get_parser():
     parser.add_argument('-e',
                         dest='tes',
                         nargs='+',
-                        help="Echo times in ms. ex: -e 14.5 38.5 62.5",
+                        help='Echo times in ms. ex: -e 14.5 38.5 62.5',
                         required=True)
     parser.add_argument('-d',
                         dest='input_ds',
                         nargs='+',
-                        help="Input datasets. ex: -d RESTe[123].nii.gz",
+                        help='Input datasets. ex: -d RESTe[123].nii.gz',
                         required=True)
     parser.add_argument('-a',
                         dest='anat',
-                        help="(Optional) anatomical dataset. " +
-                             "ex: -a mprage.nii.gz",
+                        help='(Optional) anatomical dataset. ' +
+                             'ex: -a mprage.nii.gz',
                         default='')
     parser.add_argument('-b',
                         dest='basetime',
-                        help="Time to steady-state equilibration in " +
-                             "seconds(s) or volumes(v). Default 0. ex: -b 4v",
+                        help='Time to steady-state equilibration in ' +
+                             'seconds(s) or volumes(v). Default 0. ex: -b 4v',
                         default='0')
     parser.add_argument('--MNI',
                         dest='mni',
                         action='store_true',
-                        help="Warp to MNI standard space.",
+                        help='Warp to MNI standard space.',
                         default=False)
     parser.add_argument('--strict',
                         dest='strict',
                         action='store_true',
-                        help="Use strict component selection, suitable with" +
-                             " large-voxel, high-SNR data",
+                        help='Use strict component selection, suitable with' +
+                             ' large-voxel, high-SNR data',
                         default=False)
 
     # Extended options for processing
-    extopts = parser.add_argument_group("Additional processing options")
-    extopts.add_argument("--qwarp",
+    extopts = parser.add_argument_group('Additional processing options')
+    extopts.add_argument('--qwarp',
                          dest='qwarp',
                          action='store_true',
-                         help="Nonlinear warp to standard space using QWarp," +
-                              " requires --MNI or --space).",
+                         help='Nonlinear warp to standard space using QWarp,' +
+                              ' requires --MNI or --space).',
                          default=False)
-    extopts.add_argument("--native",
+    extopts.add_argument('--native',
                          dest='native',
                          action='store_true',
-                         help="Output native space results in addition to " +
-                              "standard space results.",
+                         help='Output native space results in addition to ' +
+                              'standard space results.',
                          default=False)
-    extopts.add_argument("--space",
+    extopts.add_argument('--space',
                          dest='space',
-                         help="Path to specific standard space template for " +
-                              "affine anatomical normalization.",
+                         help='Path to specific standard space template for ' +
+                              'affine anatomical normalization.',
                          default=False)
-    extopts.add_argument("--fres",
+    extopts.add_argument('--fres',
                          dest='fres',
-                         help="Specify functional voxel dimensions in mm " +
-                              "(iso.) for resampling during preprocessing." +
-                              "ex: --fres=2.5",
+                         help='Specify functional voxel dimensions in mm ' +
+                              '(iso.) for resampling during preprocessing.' +
+                              'ex: --fres=2.5',
                          default=False)
-    extopts.add_argument("--no_skullstrip",
-                         action="store_true",
+    extopts.add_argument('--no_skullstrip',
+                         action='store_true',
                          dest='no_skullstrip',
-                         help="Anat is intensity-normalized and " +
-                              "skull-stripped (for use with '-a' flag).",
+                         help='Anat is intensity-normalized and ' +
+                              'skull-stripped (for use with '-a' flag).',
                          default=False)
-    extopts.add_argument("--no_despike",
-                         action="store_true",
+    extopts.add_argument('--no_despike',
+                         action='store_true',
                          dest='no_despike',
-                         help="Do not de-spike functional data. " +
-                              "Default is to de-spike, recommended.",
+                         help='Do not de-spike functional data. ' +
+                              'Default is to de-spike, recommended.',
                          default=False)
-    extopts.add_argument("--no_axialize",
-                         action="store_true",
+    extopts.add_argument('--no_axialize',
+                         action='store_true',
                          dest='no_axialize',
-                         help="Do not re-write dataset in axial-first order." +
-                              " Default is to axialize, recommended.",
+                         help='Do not re-write dataset in axial-first order.' +
+                              ' Default is to axialize, recommended.',
                          default=False)
-    extopts.add_argument("--mask_mode",
+    extopts.add_argument('--mask_mode',
                          dest='mask_mode',
-                         help="Mask functional with help from anatomical or" +
-                              " standard space images." +
-                              " Options: 'anat' or 'template'.",
+                         help='Mask functional with help from anatomical or' +
+                              ' standard space images.' +
+                              ' Options: "anat" or "template".',
                          default='func')
-    extopts.add_argument("--coreg_mode",
+    extopts.add_argument('--coreg_mode',
                          dest='coreg_mode',
-                         help="Coregistration with Local Pearson and T2* weights "+
-                              "(default), or use align_epi_anat.py (edge method)."+
-                              "Options: 'lp-t2s' or 'aea'",
+                         help='Coregistration with Local Pearson and T2* weights '+
+                              '(default), or use align_epi_anat.py (edge method).'+
+                              'Options: "lp-t2s" or "aea"',
                          default='lp-t2s')
-    extopts.add_argument("--smooth",
+    extopts.add_argument('--smooth',
                          dest='FWHM',
-                         help="FWHM smoothing with 3dBlurInMask. Default none. " +
-                              "ex: --smooth 3mm ",
+                         help='FWHM smoothing with 3dBlurInMask. Default none. ' +
+                              'ex: --smooth 3mm ',
                          default='0mm')
-    extopts.add_argument("--align_base",
+    extopts.add_argument('--align_base',
                          dest='align_base',
-                         help="Explicitly specify base dataset for volume " +
-                              "registration",
+                         help='Explicitly specify base dataset for volume ' +
+                              'registration',
                          default='')
-    extopts.add_argument("--TR",
+    extopts.add_argument('--TR',
                          dest='TR',
-                         help="TR. Read by default from dataset header",
+                         help='TR. Read by default from dataset header',
                          default='')
-    extopts.add_argument("--tpattern",
+    extopts.add_argument('--tpattern',
                          dest='tpattern',
-                         help="Slice timing (i.e. alt+z, see 3dTshift -help)." +
-                              " Default from header.",
+                         help='Slice timing (i.e. alt+z, see 3dTshift -help).' +
+                              ' Default from header.',
                          default='')
-    extopts.add_argument("--align_args",
+    extopts.add_argument('--align_args',
                          dest='align_args',
-                         help="Additional arguments to anatomical-functional" +
-                              " co-registration routine",
+                         help='Additional arguments to anatomical-functional' +
+                              ' co-registration routine',
                          default='')
-    extopts.add_argument("--ted_args",
+    extopts.add_argument('--ted_args',
                          dest='ted_args',
-                         help="Additional arguments to " +
-                              "TE-dependence analysis",
+                         help='Additional arguments to ' +
+                              'TE-dependence analysis',
                          default='')
 
     # Additional, extended preprocessing options
     #  no help provided, caveat emptor
-    extopts.add_argument("--select_only",
+    extopts.add_argument('--select_only',
                          dest='select_only',
                          action='store_true',
                          help=argparse.SUPPRESS,
                          default=False)
-    extopts.add_argument("--tedica_only",
+    extopts.add_argument('--tedica_only',
                          dest='tedica_only',
                          action='store_true',
                          help=argparse.SUPPRESS,
                          default=False)
-    extopts.add_argument("--export_only",
+    extopts.add_argument('--export_only',
                          dest='export_only',
                          action='store_true',
                          help=argparse.SUPPRESS,
                          default=False)
-    extopts.add_argument("--daw",
+    extopts.add_argument('--daw',
                          dest='daw',
                          help=argparse.SUPPRESS,
                          default='10')
-    extopts.add_argument("--tlrc",
+    extopts.add_argument('--tlrc',
                          dest='space',
                          help=argparse.SUPPRESS,
                          default=False)  # For backwards compat.
-    extopts.add_argument("--highpass",
+    extopts.add_argument('--highpass',
                          dest='highpass',
                          help=argparse.SUPPRESS,
                          default=0.0)
-    extopts.add_argument("--detrend",
+    extopts.add_argument('--detrend',
                          dest='detrend',
                          help=argparse.SUPPRESS,
                          default=0.)
-    extopts.add_argument("--initcost",
+    extopts.add_argument('--initcost',
                          dest='initcost',
                          help=argparse.SUPPRESS,
                          default='tanh')
-    extopts.add_argument("--finalcost",
+    extopts.add_argument('--finalcost',
                          dest='finalcost',
                          help=argparse.SUPPRESS,
                          default='tanh')
-    extopts.add_argument("--sourceTEs",
+    extopts.add_argument('--sourceTEs',
                          dest='sourceTEs',
                          help=argparse.SUPPRESS,
                          default='-1')
     parser.add_argument_group(extopts)
 
     # Extended options for running
-    runopts = parser.add_argument_group("Run options")
-    runopts.add_argument("--prefix",
+    runopts = parser.add_argument_group('Run options')
+    runopts.add_argument('--prefix',
                          dest='prefix',
-                         help="Prefix for final ME-ICA output datasets.",
+                         help='Prefix for final ME-ICA output datasets.',
                          default='')
-    runopts.add_argument("--cpus",
+    runopts.add_argument('--cpus',
                          dest='cpus',
-                         help="Maximum number of CPUs (OpenMP threads) to use. " +
-                         "Default 2.",
+                         help='Maximum number of CPUs (OpenMP threads) to use. ' +
+                         'Default 2.',
                          default='2')
-    runopts.add_argument("--label",
+    runopts.add_argument('--label',
                          dest='label',
-                         help="Label to tag ME-ICA analysis folder.",
+                         help='Label to tag ME-ICA analysis folder.',
                          default='')
-    runopts.add_argument("--test_proc",
-                         action="store_true",
+    runopts.add_argument('--test_proc',
+                         action='store_true',
                          dest='test_proc',
-                         help="Align, preprocess 1 dataset then exit.",
+                         help='Align, preprocess 1 dataset then exit.',
                          default=False)
-    runopts.add_argument("--pp_only",
-                         action="store_true",
+    runopts.add_argument('--pp_only',
+                         action='store_true',
                          dest='preproc_only',
-                         help="Preprocess only, then exit.",
+                         help='Preprocess only, then exit.',
                          default=False)
-    runopts.add_argument("--keep_int",
-                         action="store_true",
+    runopts.add_argument('--keep_int',
+                         action='store_true',
                          dest='keep_int',
-                         help="Keep preprocessing intermediates. " +
-                              "Default delete.",
+                         help='Keep preprocessing intermediates. ' +
+                              'Default delete.',
                          default=False)
-    runopts.add_argument("--RESUME",
+    runopts.add_argument('--RESUME',
                          dest='resume',
                          action='store_true',
-                         help="Attempt to resume from normalization step " +
-                              "onwards, overwriting existing")
-    runopts.add_argument("--OVERWRITE",
+                         help='Attempt to resume from normalization step ' +
+                              'onwards, overwriting existing')
+    runopts.add_argument('--OVERWRITE',
                          dest='overwrite',
-                         action="store_true",
-                         help="Overwrite existing meica directory.",
+                         action='store_true',
+                         help='Overwrite existing meica directory.',
                          default=False)
     parser.add_argument_group(runopts)
 
@@ -240,8 +240,8 @@ def main(argv=None):
     if options.label != '':
         setname = setname + options.label
 
-    with open("_meica_{}.sh".format(setname), 'w') as file_object:
-        file_object.write("\n".join(script_list))
+    with open('_meica_{}.sh'.format(setname), 'w') as file_object:
+        file_object.write('\n'.join(script_list))
 
 
 if __name__ == '__main__':

--- a/scripts/run_t2smap.py
+++ b/scripts/run_t2smap.py
@@ -16,20 +16,20 @@ def get_parser():
     parser.add_option('-d',
                       nargs='+',
                       dest='data',
-                      help="Spatially Concatenated Multi-Echo Dataset",
+                      help='Spatially Concatenated Multi-Echo Dataset',
                       required=True)
     parser.add_option('-e',
                       nargs='+',
                       dest='tes',
-                      help="Echo times (in ms) ex: 15,39,63",
+                      help='Echo times (in ms) ex: 15,39,63',
                       required=True)
     parser.add_option('-c',
                       dest='combmode',
-                      help="Combination scheme for TEs: t2s (Posse 1999),ste(Poser,2006 default)",
+                      help='Combination scheme for TEs: t2s (Posse 1999),ste(Poser,2006 default)',
                       default='ste')
     parser.add_option('-l',
                       dest='label',
-                      help="Optional label to tag output files with",
+                      help='Optional label to tag output files with',
                       default=None)
     return parser
 

--- a/scripts/run_t2smap.py
+++ b/scripts/run_t2smap.py
@@ -1,0 +1,44 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+import argparse
+
+from meica import t2smap
+
+
+def get_parser():
+    """
+    Parses command line inputs for t2smap
+    Returns
+    -------
+    parser.parse_args() : argparse dic
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_option('-d',
+                      nargs='+',
+                      dest='data',
+                      help="Spatially Concatenated Multi-Echo Dataset",
+                      required=True)
+    parser.add_option('-e',
+                      nargs='+',
+                      dest='tes',
+                      help="Echo times (in ms) ex: 15,39,63",
+                      required=True)
+    parser.add_option('-c',
+                      dest='combmode',
+                      help="Combination scheme for TEs: t2s (Posse 1999),ste(Poser,2006 default)",
+                      default='ste')
+    parser.add_option('-l',
+                      dest='label',
+                      help="Optional label to tag output files with",
+                      default=None)
+    return parser
+
+
+def main(argv=None):
+    parser = get_parser()
+    options = parser.parse_args(argv)
+    t2smap.main(options)
+
+
+if __name__=='__main__':
+    main()

--- a/scripts/run_tedana.py
+++ b/scripts/run_tedana.py
@@ -1,0 +1,134 @@
+"""Command-line interaction with tedana.
+"""
+
+import argparse
+
+from meica import tedana
+
+
+def get_parser():
+    """
+    Parses command line inputs for tedana
+    Returns
+    -------
+    parser.parse_args() : argparse dict
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d',
+                        dest='data',
+                        nargs='+',
+                        help="Spatially Concatenated Multi-Echo Dataset",
+                        required=True)
+    parser.add_argument('-e',
+                        dest='tes',
+                        nargs='+',
+                        help="Echo times (in ms) ex: 15,39,63",
+                        required=True)
+    parser.add_argument("--mix",
+                        dest='mixm',
+                        help="Mixing matrix. If not provided, " +
+                             "ME-PCA & ME-ICA is done.",
+                        default=None)
+    parser.add_argument("--ctab",
+                        dest='ctab',
+                        help="Component table extract pre-computed " +
+                             "classifications from.",
+                        default=None)
+    parser.add_argument("--manacc",
+                        dest='manacc',
+                        help="Comma separated list of manually " +
+                             "accepted components",
+                        default=None)
+    parser.add_argument("--strict",
+                        dest='strict',
+                        action='store_true',
+                        help="Ignore low-variance ambiguous components",
+                        default=False)
+    parser.add_argument("--no_gscontrol",
+                        dest='no_gscontrol',
+                        action='store_true',
+                        help="Control global signal using spatial approach",
+                        default=False)
+    parser.add_argument("--kdaw",
+                        dest='kdaw',
+                        help="Dimensionality augmentation weight " +
+                             "(Kappa). Default 10. -1 for low-dimensional ICA",
+                        default=10.)
+    parser.add_argument("--rdaw",
+                        dest='rdaw',
+                        help="Dimensionality augmentation weight (Rho). " +
+                             "Default 1. -1 for low-dimensional ICA",
+                        default=1.)
+    parser.add_argument("--conv",
+                        dest='conv',
+                        help="Convergence limit. Default 2.5e-5",
+                        default='2.5e-5')
+    parser.add_argument("--sourceTEs",
+                        dest='ste',
+                        help="Source TEs for models. ex: -ste 0 for all, " +
+                             "-1 for opt. com. Default -1.",
+                        default=-1)
+    parser.add_argument("--combmode",
+                        dest='combmode',
+                        help="Combination scheme for TEs: t2s " +
+                             "(Posse 1999, default),ste(Poser)",
+                        default='t2s')
+    parser.add_argument("--denoiseTEs",
+                        dest='dne',
+                        action='store_true',
+                        help="Denoise each TE dataset separately",
+                        default=False)
+    parser.add_argument("--initcost",
+                        dest='initcost',
+                        help="Initial cost func. for ICA: pow3, " +
+                             "tanh(default), gaus, skew",
+                        default='tanh')
+    parser.add_argument("--finalcost",
+                        dest='finalcost',
+                        help="Final cost func, same opts. as initial",
+                        default='tanh')
+    parser.add_argument("--stabilize",
+                        dest='stabilize',
+                        action='store_true',
+                        help="Stabilize convergence by reducing " +
+                             "dimensionality, for low quality data",
+                        default=False)
+    parser.add_argument("--fout",
+                        dest='fout',
+                        help="Output TE-dependence Kappa/Rho SPMs",
+                        action="store_true",
+                        default=False)
+    parser.add_argument("--filecsdata",
+                        dest='filecsdata',
+                        help="Save component selection data",
+                        action="store_true",
+                        default=False)
+    parser.add_argument("--label",
+                        dest='label',
+                        help="Label for output directory.",
+                        default=None)
+    parser.add_argument("--seed",
+                        dest='fixed_seed',
+                        help="Seeded value for ICA, for reproducibility.",
+                        default=42)
+    return parser
+
+
+def main(argv=None):
+    """
+    Args to tedana.main (eventually)
+    data=options.data, tes=options.tes, mixm=options.mixm,
+                ctab=options.ctab, manacc=options.manacc, strict=options.strict,
+                no_gscontrol=options.no_gscontrol, kdaw=options.kdaw,
+                rdaw=options.rdaw, conv=options.conv, ste=options.ste,
+                combmode=options.combmode, dne=options.dne, initcost=options.initcost,
+                finalcost=options.finalcost, stabilize=options.stabilize,
+                fout=options.fout, filecsdata=options.filecsdata, label=options.label,
+                fixed_seed=options.fixed_seed
+    """
+    parser = get_parser()
+    options = parser.parse_args(argv)
+    tedana.main(options)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/run_tedana.py
+++ b/scripts/run_tedana.py
@@ -17,99 +17,99 @@ def get_parser():
     parser.add_argument('-d',
                         dest='data',
                         nargs='+',
-                        help="Spatially Concatenated Multi-Echo Dataset",
+                        help='Spatially Concatenated Multi-Echo Dataset',
                         required=True)
     parser.add_argument('-e',
                         dest='tes',
                         nargs='+',
-                        help="Echo times (in ms) ex: 15,39,63",
+                        help='Echo times (in ms) ex: 15,39,63',
                         required=True)
-    parser.add_argument("--mix",
+    parser.add_argument('--mix',
                         dest='mixm',
-                        help="Mixing matrix. If not provided, " +
-                             "ME-PCA & ME-ICA is done.",
+                        help='Mixing matrix. If not provided, ' +
+                             'ME-PCA & ME-ICA is done.',
                         default=None)
-    parser.add_argument("--ctab",
+    parser.add_argument('--ctab',
                         dest='ctab',
-                        help="Component table extract pre-computed " +
-                             "classifications from.",
+                        help='Component table extract pre-computed ' +
+                             'classifications from.',
                         default=None)
-    parser.add_argument("--manacc",
+    parser.add_argument('--manacc',
                         dest='manacc',
-                        help="Comma separated list of manually " +
-                             "accepted components",
+                        help='Comma separated list of manually ' +
+                             'accepted components',
                         default=None)
-    parser.add_argument("--strict",
+    parser.add_argument('--strict',
                         dest='strict',
                         action='store_true',
-                        help="Ignore low-variance ambiguous components",
+                        help='Ignore low-variance ambiguous components',
                         default=False)
-    parser.add_argument("--no_gscontrol",
+    parser.add_argument('--no_gscontrol',
                         dest='no_gscontrol',
                         action='store_true',
-                        help="Control global signal using spatial approach",
+                        help='Control global signal using spatial approach',
                         default=False)
-    parser.add_argument("--kdaw",
+    parser.add_argument('--kdaw',
                         dest='kdaw',
-                        help="Dimensionality augmentation weight " +
-                             "(Kappa). Default 10. -1 for low-dimensional ICA",
+                        help='Dimensionality augmentation weight ' +
+                             '(Kappa). Default 10. -1 for low-dimensional ICA',
                         default=10.)
-    parser.add_argument("--rdaw",
+    parser.add_argument('--rdaw',
                         dest='rdaw',
-                        help="Dimensionality augmentation weight (Rho). " +
-                             "Default 1. -1 for low-dimensional ICA",
+                        help='Dimensionality augmentation weight (Rho). ' +
+                             'Default 1. -1 for low-dimensional ICA',
                         default=1.)
-    parser.add_argument("--conv",
+    parser.add_argument('--conv',
                         dest='conv',
-                        help="Convergence limit. Default 2.5e-5",
+                        help='Convergence limit. Default 2.5e-5',
                         default='2.5e-5')
-    parser.add_argument("--sourceTEs",
+    parser.add_argument('--sourceTEs',
                         dest='ste',
-                        help="Source TEs for models. ex: -ste 0 for all, " +
-                             "-1 for opt. com. Default -1.",
+                        help='Source TEs for models. ex: -ste 0 for all, ' +
+                             '-1 for opt. com. Default -1.',
                         default=-1)
-    parser.add_argument("--combmode",
+    parser.add_argument('--combmode',
                         dest='combmode',
-                        help="Combination scheme for TEs: t2s " +
-                             "(Posse 1999, default),ste(Poser)",
+                        help='Combination scheme for TEs: t2s ' +
+                             '(Posse 1999, default),ste(Poser)',
                         default='t2s')
-    parser.add_argument("--denoiseTEs",
+    parser.add_argument('--denoiseTEs',
                         dest='dne',
                         action='store_true',
-                        help="Denoise each TE dataset separately",
+                        help='Denoise each TE dataset separately',
                         default=False)
-    parser.add_argument("--initcost",
+    parser.add_argument('--initcost',
                         dest='initcost',
-                        help="Initial cost func. for ICA: pow3, " +
-                             "tanh(default), gaus, skew",
+                        help='Initial cost func. for ICA: pow3, ' +
+                             'tanh(default), gaus, skew',
                         default='tanh')
-    parser.add_argument("--finalcost",
+    parser.add_argument('--finalcost',
                         dest='finalcost',
-                        help="Final cost func, same opts. as initial",
+                        help='Final cost func, same opts. as initial',
                         default='tanh')
-    parser.add_argument("--stabilize",
+    parser.add_argument('--stabilize',
                         dest='stabilize',
                         action='store_true',
-                        help="Stabilize convergence by reducing " +
-                             "dimensionality, for low quality data",
+                        help='Stabilize convergence by reducing ' +
+                             'dimensionality, for low quality data',
                         default=False)
-    parser.add_argument("--fout",
+    parser.add_argument('--fout',
                         dest='fout',
-                        help="Output TE-dependence Kappa/Rho SPMs",
-                        action="store_true",
+                        help='Output TE-dependence Kappa/Rho SPMs',
+                        action='store_true',
                         default=False)
-    parser.add_argument("--filecsdata",
+    parser.add_argument('--filecsdata',
                         dest='filecsdata',
-                        help="Save component selection data",
-                        action="store_true",
+                        help='Save component selection data',
+                        action='store_true',
                         default=False)
-    parser.add_argument("--label",
+    parser.add_argument('--label',
                         dest='label',
-                        help="Label for output directory.",
+                        help='Label for output directory.',
                         default=None)
-    parser.add_argument("--seed",
+    parser.add_argument('--seed',
                         dest='fixed_seed',
-                        help="Seeded value for ICA, for reproducibility.",
+                        help='Seeded value for ICA, for reproducibility.',
                         default=42)
     return parser
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
+"""Set up MEICA module.
+"""
 from setuptools import setup
 
-__version__ = '3.2.1'
+# fetch version from within meica module
+with open('meica/version.py') as f:
+    exec(f.read())
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()


### PR DESCRIPTION
- I added duecredit to the package, as well as citations for the Dice similarity index.
    - Actually, I also changed the underlying code for `utils.dice` to be more explicit based on a great [gist](https://gist.github.com/brunodoamaral/e130b4e97aa4ebc468225b7ce39b3137).
- I changed the arguments for `tedana.do_svm` to match sklearn's [convention](https://github.com/scikit-learn/scikit-learn/blob/f3320a6f/sklearn/svm/base.py#L293). I also changed the documentation somewhat to (hopefully) match sklearn's.
- I added in some argument checks for rankvec.
- Other than that, I just did some light refactoring. Mostly splitting long lines and cleaning up whitespace. The `pcscore` definition in `tedana.tedpca`, in particular, was a couple of very long lines. I took the chunks from that and created new variables for them. The variables are all named `temp[0:9]`, which will need to be changed, but I think it's more readable overall.